### PR TITLE
Enabled scribble toolbar

### DIFF
--- a/lang/reader.rkt
+++ b/lang/reader.rkt
@@ -12,12 +12,12 @@ hyper-literate/lang
 #:info (wrapped-scribble-base-reader-info)
 (require "meta-first-line.rkt"
          (only-in scribble/base/reader
-                  scribble-base-reader-info
+                  scribble-base-info
                   scribble-base-language-info)
          "first-line-utils.rkt")
 
-(define orig-scribble-base-reader-info
-  (scribble-base-reader-info))
+(define orig-scribble-base-info
+  (scribble-base-info))
 
 (require syntax-color/scribble-lexer
          syntax-color/racket-lexer
@@ -84,4 +84,4 @@ hyper-literate/lang
            [else
             (read/at-exp in offset x-mode)]))]
       [else
-       (orig-scribble-base-reader-info key defval default)])))
+       (orig-scribble-base-info key defval default)])))


### PR DESCRIPTION
Wrapped `scribble-base-info` instead of `scribble-base-reader-info` for the reader `get-info` function. This version of the info function tells DrRacket to display the scribble toolbar. This fixes Issue #3.